### PR TITLE
Fix chrome 53 "will-change" side-effect on tooltip

### DIFF
--- a/src/tooltip/_tooltip.scss
+++ b/src/tooltip/_tooltip.scss
@@ -19,6 +19,7 @@
 .mdl-tooltip {
   transform: scale(0);
   transform-origin: top center;
+  will-change: transform;
   z-index: 999;
   background: $tooltip-background-color;
   border-radius: 2px;
@@ -35,6 +36,7 @@
   text-align: center;
 }
 .mdl-tooltip.is-active {
+  will-change: auto;
   animation: pulse 200ms $animation-curve-linear-out-slow-in forwards;
 }
 


### PR DESCRIPTION
Removing the "will-change" property will cause tooltip disappear immediately after mouseover, but keeping it will make text become blurry.
This solution is from here: http://greensock.com/will-change
